### PR TITLE
Use Zypper to create Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
 FROM scratch
-ADD baseimage.tar /
+ADD / /
 
-# copy tools
-COPY \
-    scripts/buildrpm \
-    scripts/rpm-install-build-deps \
-    rpmdevtools/rpmdev-spectool \
-    rpmdevtools/rpmdev-setuptree \
-    /usr/bin/
+# rpm database rebuild: somehow doesn't work
+#RUN rm -f /var/lib/rpm/__db*
+#RUN rpm --rebuilddb || echo "For some reason it fails, ignore"
 
-# ssu release
-RUN ssu re @RELEASE@
-
-# rpm target
-RUN echo @RPMTARGET@ > /etc/rpmtarget
+# skipping install of SSU - handle repositories via zypper
+#
+# # setup ssu - cannot be installed in setup-root due to gpg errors
+# RUN zypper --non-interactive in ssu ssu-vendor-data-jolla
+# RUN ssu re @RELEASE@
 
 # install required dependencies
 RUN pip3 install progressbar requests
+RUN rm -rf /root/.cache
 
 # create source location
 RUN mkdir /source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM scratch
 ADD / /
 
-# rpm database rebuild: somehow doesn't work
-#RUN rm -f /var/lib/rpm/__db*
-#RUN rpm --rebuilddb || echo "For some reason it fails, ignore"
+# rpm database rebuild: somehow doesn't work cleanly
+RUN rm -f /var/lib/rpm/__db*
+RUN \
+    rpm --rebuilddb || \
+    echo "For some reason it fails, ignore. It does rebuild anyway." \
+    rm -rf /var/lib/rpmrebuilddb.* || \
+    echo "Makes sense to remove if it failed above"
 
 # skipping install of SSU - handle repositories via zypper
 #

--- a/makeimage
+++ b/makeimage
@@ -43,18 +43,44 @@ case "$SFOS_ARCH" in
 	exit -1
 esac
 
-rm -f baseimage.tar
-cp base.ks base_${SFOS_ARCH}_${RELEASE}.ks
-docker run --rm --privileged --network=host -v $(pwd):/share -w /share coderus/sailfishos-baseimage \
-       mic create fs -v -d --arch=$SFOS_ARCH --outdir=/share --tokenmap=ARCH:${SFOS_ARCH},RELEASE:$RELEASE \
-       --pack-to=baseimage.tar base_${SFOS_ARCH}_${RELEASE}.ks
+# allocate temp directory and ensure it is removed on exit
+SFOS_DIR=`mktemp -d`
 
-# coderus/sailfishos-baseimage works with /proc/sys/fs/binfmt_misc
-# which disturbs the handling by QEMU later. so, restart
-# systemd-binfmt as a workaround. issue #1
-systemctl restart systemd-binfmt
+if [[ ! "$SFOS_DIR" || ! -d "$SFOS_DIR" ]]; then
+  echo "Could not create temporary directory for Sailfish OS root"
+  exit 1
+fi
 
-cat Dockerfile | sed -e "s/@RELEASE@/$RELEASE/g" | sed -e "s/@RPMTARGET@/$RPMTARGET/g" | \
-    docker build -t sailfishos-${SFOS_ARCH}-${RELEASE} --platform=linux/$DOCKER_PLATFORM_ARCH -f- .
+echo "Temporary directory used to create Sailfish OS root: $SFOS_DIR"
 
-rm baseimage.tar
+# deletes the temp directory
+function cleanup {
+  rm -rf "$SFOS_DIR"
+  echo "Deleted temp working directory $SFOS_DIR"
+}
+
+# register the cleanup function to be called on the EXIT signal
+trap cleanup EXIT
+
+# create root using coderus/sailfishos-baseimage
+cat scripts/setup-root |
+    sed -e "s/@RELEASE@/$RELEASE/g" |
+    sed -e "s/@ARCH@/$SFOS_ARCH/g" |
+    sed -e "s/@RPMTARGET@/$RPMTARGET/g" |
+    docker run --rm -i -v $SFOS_DIR:/sfos coderus/sailfishos-baseimage \
+	   bash
+
+# copy tools used for building
+cp \
+    scripts/buildrpm \
+    scripts/rpm-install-build-deps \
+    rpmdevtools/rpmdev-spectool \
+    rpmdevtools/rpmdev-setuptree \
+    $SFOS_DIR/usr/bin/
+
+cat Dockerfile | \
+    sed -e "s/@RELEASE@/$RELEASE/g" |
+    sed -e "s/@ARCH@/$SFOS_ARCH/g" |
+    sed -e "s/@RPMTARGET@/$RPMTARGET/g" |
+    docker build -t sailfishos-${SFOS_ARCH}-${RELEASE} --platform=linux/$DOCKER_PLATFORM_ARCH -f- \
+	   $SFOS_DIR

--- a/scripts/buildrpm
+++ b/scripts/buildrpm
@@ -42,7 +42,7 @@ while getopts 'sr:h' opt; do
       r)
 	  arg="$OPTARG"
 	  echo "Adding repository $arg"
-	  ssu ar repo-$OPTIND $arg
+	  zypper ar --gpgcheck-allow-unsigned $arg repo-$OPTIND
 	  echo
 	  ;;
 

--- a/scripts/rpm-install-build-deps
+++ b/scripts/rpm-install-build-deps
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 SPEC=$1
-rpmspec --buildrequires -q $SPEC | xargs zypper in -y
+rpmspec --buildrequires -q $SPEC |
+    xargs zypper --non-interactive in

--- a/scripts/setup-root
+++ b/scripts/setup-root
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -ex
+
+INSTALL_ROOT=/sfos
+
+PACKAGES="
+atruncate
+attr
+basesystem
+gcc-c++
+gnu-bash
+gnu-coreutils
+gnu-cpio
+gnu-diffutils
+gnu-findutils
+gnu-grep
+gnu-gzip
+gnu-sed
+gnu-tar
+gnu-which
+deltarpm
+file
+jolla-ca
+kbd
+make
+meego-rpm-config
+net-tools
+passwd
+pigz
+procps-ng
+psmisc-tools
+python3-pip
+rootfiles
+rpm-build
+rpmlint
+sailfish-ca
+shadow-utils
+util-linux
+xdg-utils
+zypper
+"
+
+# switch arch to the desired one
+echo "arch = @ARCH@" >> /etc/zypp/zypp.conf
+
+# init rpm database
+rpm --root $INSTALL_ROOT --initdb
+
+# define repositories
+zypper --root $INSTALL_ROOT ar \
+       https://releases.jolla.com/releases/@RELEASE@/jolla-hw/adaptation-common/@ARCH@/ adaptation-common
+zypper --root $INSTALL_ROOT ar https://releases.jolla.com/jolla-apps/@RELEASE@/@ARCH@/ apps
+zypper --root $INSTALL_ROOT ar https://releases.jolla.com/releases/@RELEASE@/hotfixes/@ARCH@/ hotfixes
+zypper --root $INSTALL_ROOT ar https://releases.jolla.com/releases/@RELEASE@/jolla/@ARCH@/ jolla
+
+# install packages
+zypper --gpg-auto-import-keys --non-interactive \
+       --root $INSTALL_ROOT in $PACKAGES
+
+echo -n "@ARCH@-meego-linux" > $INSTALL_ROOT/etc/rpm/platform
+echo "arch = @ARCH@" >> $INSTALL_ROOT/etc/zypp/zypp.conf
+echo "BUILD: SailfishOS Builder" >> $INSTALL_ROOT/etc/meego-release
+
+# rpmtarget used by buildrpm
+echo @RPMTARGET@ > $INSTALL_ROOT/etc/rpmtarget
+
+# drop lastlog - Docker will just waste storage on it
+rm -f $INSTALL_ROOT/var/log/lastlog
+rm -rf $INSTALL_ROOT/home/.zypp-cache


### PR DESCRIPTION
This allows to avoid `mic` and its handling of QEMU settings. The image packages are now given in scripts/setup-root with some final handling in Dockerfile

In addition, tmp directory is used to create the image.

Fixes: #1 